### PR TITLE
Improve error handling, allow compile on non-linux platform

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -8,6 +8,8 @@
 #include <fmt/os.h>
 #include <spdlog/spdlog.h>
 
+#ifdef __linux__
+
 #include <sys/inotify.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -157,3 +159,9 @@ void create(std::string name_) {
     }
   }
 }
+
+#else
+
+void create(std::string) {}
+
+#endif

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -122,9 +122,19 @@ void enter_chroot_jail(std::shared_ptr<spdlog::logger> logger) {
   logger->info("Chroot jail entered.");
 }
 
-void initialize() {
+void initialize_logger() {
   setup_loggers();
   set_log_level();
+}
+
+void check_cgroup_mount() {
+  auto logger = spdlog::get("initialize");
+  auto p = fs::path(cgroup_procs);
+  if (fs::exists(p)) {
+    return;
+  }
+  logger->critical("Cgroup v2 not mounted");
+  exit(1);
 }
 
 bool is_sandbox;

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -127,8 +127,7 @@ void initialize_logger() {
   set_log_level();
 }
 
-void check_cgroup_mount() {
-  auto logger = spdlog::get("initialize");
+void check_cgroup_mount(std::shared_ptr<spdlog::logger> logger) {
   auto p = fs::path(cgroup_procs);
   if (fs::exists(p)) {
     return;
@@ -142,6 +141,7 @@ bool is_sandbox;
 void enter_sandbox() {
   auto logger = spdlog::get("initialize");
   logger->info("Entering sandbox...");
+  check_cgroup_mount(logger);
   create_root_dir(logger);
   enter_chroot_jail(logger);
   is_sandbox = true;

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -53,6 +53,10 @@ void list() {
   auto r = user_dir();
   logger->debug("Root directory is {}, iterating it.", r);
   fs::path p(r);
+  if (!fs::exists(p)) {
+    logger->debug("Root directory does not exist, showing empty list.");
+    return;
+  }
   fs::recursive_directory_iterator end;
   for (fs::recursive_directory_iterator i(p); i != end; ++i) {
     if (fs::is_directory(*i)) {

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -54,7 +54,7 @@ void list() {
   logger->debug("Root directory is {}, iterating it.", r);
   fs::path p(r);
   if (!fs::exists(p)) {
-    logger->debug("Root directory does not exist, showing empty list.");
+    logger->info("Root directory does not exist, showing empty list.");
     return;
   }
   fs::recursive_directory_iterator end;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,8 @@ void check_arg(bool condition) {
   invalid_argument();
 }
 
-void initialize();
+void initialize_logger();
+void check_cgroup_mount();
 void enter_sandbox();
 void help();
 void list();
@@ -21,7 +22,7 @@ void set(std::string name, std::string key, std::string value);
 void show(std::string name, std::string key);
 
 int main(int argc, const char *argv[]) {
-  initialize();
+  initialize_logger();
   check_arg(argc >= 2);
 
   std::string command = argv[1];
@@ -33,7 +34,11 @@ int main(int argc, const char *argv[]) {
     // support
     help();
     return 0;
-  } else if (command == "list" || command == "ls" || command == "l") {
+  }
+
+  check_cgroup_mount();
+
+  if (command == "list" || command == "ls" || command == "l") {
     // list has to run outside sandbox because
     // it needs access to /proc filesystem
     check_arg(argc == 2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,6 @@ void check_arg(bool condition) {
 }
 
 void initialize_logger();
-void check_cgroup_mount();
 void enter_sandbox();
 void help();
 void list();
@@ -34,21 +33,13 @@ int main(int argc, const char *argv[]) {
     // support
     help();
     return 0;
-  }
-
-  check_cgroup_mount();
-
-  if (command == "list" || command == "ls" || command == "l") {
+  } else if (command == "list" || command == "ls" || command == "l") {
     // list has to run outside sandbox because
     // it needs access to /proc filesystem
     check_arg(argc == 2);
     list();
     return 0;
-  }
-
-  check_cgroup_mount();
-
-  if (command == "self" || command == "sf") {
+  } else if (command == "self" || command == "sf") {
     // self has to run outside sandbox because
     // it needs access to /proc filesystem
     self();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,14 +44,18 @@ int main(int argc, const char *argv[]) {
     check_arg(argc == 2);
     list();
     return 0;
-  } else if (command == "self" || command == "sf") {
+  }
+
+  check_cgroup_mount();
+
+  if (command == "self" || command == "sf") {
     // self has to run outside sandbox because
     // it needs access to /proc filesystem
     self();
     return 0;
-  } else {
-    enter_sandbox();
   }
+
+  enter_sandbox();
 
   if (command == "create" || command == "c") {
     check_arg(argc == 2 || argc == 3);

--- a/src/self.cpp
+++ b/src/self.cpp
@@ -2,9 +2,9 @@
 #include <string>
 #include <unistd.h>
 
+#include <boost/filesystem.hpp>
 #include <fmt/core.h>
 #include <spdlog/spdlog.h>
-#include <boost/filesystem.hpp>
 
 #include "utils.hpp"
 

--- a/src/self.cpp
+++ b/src/self.cpp
@@ -16,7 +16,7 @@ void self() {
   auto pid = getpid();
   auto cg = fmt::format("/proc/{}/cgroup", pid);
   if (!fs::exists(fs::path(cg))) {
-    logger->critical("Procfs not mounted, or cgroup not enabled");
+    logger->info("Procfs not mounted, or cgroup not enabled");
     exit(1);
   }
   logger->debug("Reading {}...", cg);

--- a/src/self.cpp
+++ b/src/self.cpp
@@ -4,14 +4,21 @@
 
 #include <fmt/core.h>
 #include <spdlog/spdlog.h>
+#include <boost/filesystem.hpp>
 
 #include "utils.hpp"
+
+namespace fs = boost::filesystem;
 
 void self() {
   auto logger = spdlog::get("self");
   logger->info("Getting the cgroup for the current shell");
   auto pid = getpid();
   auto cg = fmt::format("/proc/{}/cgroup", pid);
+  if (!fs::exists(fs::path(cg))) {
+    logger->critical("Procfs not mounted, or cgroup not enabled");
+    exit(1);
+  }
   logger->debug("Reading {}...", cg);
   auto uid = getuid();
   auto userdir = fmt::format("/terminals/{}/", uid);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+constexpr const char *cgroup_procs = "/sys/fs/cgroup/cgroup.procs";
 constexpr const char *root_dir = "/sys/fs/cgroup/terminals";
 
 std::string user_dir();


### PR DESCRIPTION
On a non-Linux platform, you can compile and run help, ls, and self, the latter two will show an empty output