### PR TITLE
Fix build on non-linux system

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -8,14 +8,14 @@
 #include <fmt/os.h>
 #include <spdlog/spdlog.h>
 
+#include "utils.hpp"
+
 #ifdef __linux__
 
 #include <sys/inotify.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-
-#include "utils.hpp"
 
 namespace fs = boost::filesystem;
 


### PR DESCRIPTION
This allows viewing help information on other systems